### PR TITLE
fix: force LF on shell scripts so shebangs don't break (CRLF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must use LF line endings — a CRLF on the shebang line makes
+# the kernel look for "/bin/bash\r" and fail with "bad interpreter".
+*.sh text eol=lf


### PR DESCRIPTION
Closes #44.

A shell script checked out with Windows CRLF line endings gets a `#!/bin/bash\r` shebang; the kernel then looks for the interpreter `/bin/bash\r` (shown as `/bin/bash^M`) and fails with `bad interpreter: No such file or directory`. `core.autocrlf` normalizes CRLF only on **commit**, never on **checkout**, so a working tree that picks up CRLF stays broken.

This adds `.gitattributes` with `*.sh text eol=lf`, which forces LF in the working tree on every checkout regardless of each user's global git config. No committed shell scripts in this repo currently have CRLF, so this is purely preventive — no file renormalization.