### PR TITLE
Repoint gha reusable workflows to Morrison-Lab/gha

### DIFF
--- a/.github/workflows/check-bibliography-dois.yml
+++ b/.github/workflows/check-bibliography-dois.yml
@@ -1,5 +1,5 @@
 # Validates DOIs in the repo's .bib files, via the reusable workflow in
-# d-morrison/gha. Pinned to the @v2 moving major tag.
+# Morrison-Lab/gha. Pinned to the @v2 moving major tag.
 name: Check Bibliography DOIs
 
 on:
@@ -10,4 +10,4 @@ on:
 
 jobs:
   check:
-    uses: d-morrison/gha/.github/workflows/check-bibliography-dois.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/check-bibliography-dois.yml@v2

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,5 +1,5 @@
 # Validates URLs in the docs with lychee, via the reusable workflow in
-# d-morrison/gha. On main/scheduled runs it may file a broken-links tracking
+# Morrison-Lab/gha. On main/scheduled runs it may file a broken-links tracking
 # issue; on PRs add the `links checked by hand` label to skip.
 #
 # Single job (per gha's example): the reusable link-checker job declares
@@ -24,6 +24,6 @@ jobs:
       contents: read
       issues: write
       pull-requests: read
-    uses: d-morrison/gha/.github/workflows/check-links.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/check-links.yml@v2
     with:
       lychee-config: lychee.toml

--- a/.github/workflows/check-non-standard-chars.yml
+++ b/.github/workflows/check-non-standard-chars.yml
@@ -1,5 +1,5 @@
 # Flags curly quotes and en/em dashes in source files, via the reusable workflow
-# in d-morrison/gha. Pinned to the @v2 moving major tag.
+# in Morrison-Lab/gha. Pinned to the @v2 moving major tag.
 name: Check Non-Standard Characters
 
 on:
@@ -11,4 +11,4 @@ on:
 
 jobs:
   check:
-    uses: d-morrison/gha/.github/workflows/check-non-standard-chars.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/check-non-standard-chars.yml@v2

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,4 +1,4 @@
-# Calls the reusable Claude review workflow in d-morrison/gha. The
+# Calls the reusable Claude review workflow in Morrison-Lab/gha. The
 # workflow_dispatch path lets claude.yml re-dispatch a review after an @claude
 # run pushes commits — keep this file named claude-code-review.yml.
 #
@@ -23,7 +23,7 @@ jobs:
       issues: write
       id-token: write
       actions: read
-    uses: d-morrison/gha/.github/workflows/claude-code-review.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/claude-code-review.yml@v2
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,4 @@
-# Calls the reusable Claude Code workflow in d-morrison/gha. Secrets are passed
+# Calls the reusable Claude Code workflow in Morrison-Lab/gha. Secrets are passed
 # explicitly (not via `secrets: inherit`) so the cross-repo call always forwards
 # a real token. The reusable workflow enforces the @claude mention + trusted-author
 # gate, so no caller-side `if:` is needed.
@@ -24,7 +24,7 @@ jobs:
       issues: write
       id-token: write
       actions: write
-    uses: d-morrison/gha/.github/workflows/claude.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/claude.yml@v2
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       SUBMODULES_TOKEN: ${{ secrets.SUBMODULES_TOKEN }}

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -1,5 +1,5 @@
 # AI-generated summary comment on newly opened issues, via the reusable workflow
-# in d-morrison/gha. Uses GitHub Models (the `models: read` grant), no extra secret.
+# in Morrison-Lab/gha. Uses GitHub Models (the `models: read` grant), no extra secret.
 #
 # Pinned to the @v2 moving major tag.
 name: Issue Summary
@@ -14,4 +14,4 @@ jobs:
       contents: read
       issues: write
       models: read
-    uses: d-morrison/gha/.github/workflows/summary.yml@v2
+    uses: Morrison-Lab/gha/.github/workflows/summary.yml@v2


### PR DESCRIPTION
The `gha` repo moved from `d-morrison/gha` to `Morrison-Lab/gha`.

GitHub Actions does **not** follow repository-rename redirects for `uses:`, so
every call in this repo was failing to resolve before any job started. This
repoints all 12 reference(s) across 6 workflow file(s). Tags and paths
are unchanged.

Direct push to the default branch was blocked by repository rules, so this is a PR.